### PR TITLE
Template user auth

### DIFF
--- a/server/src/template/template.controller.ts
+++ b/server/src/template/template.controller.ts
@@ -26,7 +26,6 @@ import {
 } from '@nestjs/swagger';
 import { Template } from './schemas/template.schema';
 import { TemplateService } from './template.service';
-import { UserDocument } from '../user/user.schema';
 
 @ApiTags('templates')
 @Controller('/template')
@@ -105,7 +104,7 @@ export class TemplateController {
     if (!req.user) throw new UnauthorizedException('User is not logged in');
     if (!template) throw new BadRequestException('Template is not defined');
     if (!id) throw new BadRequestException('ID is not defined');
-    if (!(await this.templateService.verifyAuthor(id, req.user as UserDocument))) {
+    if (!(await this.templateService.verifyAuthor(id as any, req.user['_id']))) {
       throw new ForbiddenException('Access forbidden');
     }
     return await this.templateService.updateTemplate(id, template);
@@ -121,7 +120,7 @@ export class TemplateController {
   async deleteTemplate(@Param('id') id: string, @Req() req: Request): Promise<boolean> {
     if (!req.user) throw new UnauthorizedException('User is not logged in');
     if (!id) throw new BadRequestException('ID is not defined');
-    if (!(await this.templateService.verifyAuthor(id, req.user as UserDocument))) {
+    if (!(await this.templateService.verifyAuthor(id as any, req.user['_id']))) {
       throw new ForbiddenException('Access forbidden');
     }
     return await this.templateService.deleteTemplate(id);

--- a/server/src/template/template.controller.ts
+++ b/server/src/template/template.controller.ts
@@ -1,4 +1,5 @@
 import {
+  Req,
   Body,
   Controller,
   Delete,
@@ -8,16 +9,24 @@ import {
   Post,
   UsePipes,
   ValidationPipe,
+  UnauthorizedException,
+  BadRequestException,
+  ForbiddenException,
 } from '@nestjs/common';
+import { Request } from 'express';
 import {
   ApiBadRequestResponse,
   ApiCreatedResponse,
+  ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
+  ApiOperation,
   ApiTags,
+  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
-import { Template, TemplateDocument } from './schemas/template.schema';
+import { Template } from './schemas/template.schema';
 import { TemplateService } from './template.service';
+import { UserDocument } from '../user/user.schema';
 
 @ApiTags('templates')
 @Controller('/template')
@@ -25,61 +34,96 @@ export class TemplateController {
   constructor(private readonly templateService: TemplateService) {}
 
   @Post('/')
+  @ApiOperation({ summary: 'Creates new template using body contents' })
   @ApiCreatedResponse({ description: 'Template created succesfully', type: Template })
-  @ApiBadRequestResponse({ description: 'Invalid request body' })
+  @ApiBadRequestResponse({ description: 'Invalid or missing request body' })
+  @ApiUnauthorizedResponse({ description: 'User is not authenticated' })
   @UsePipes(new ValidationPipe({ transform: true }))
-  async createTemplate(@Body() template: Template): Promise<Template> {
-    const created = (await this.templateService.createTemplate(template)) as TemplateDocument;
-    // Return only selected values
-    const returnObj = {
-      title: created.title,
-      author: created.author,
-      terms: created.terms,
-      _id: created._id,
-    };
-    return returnObj as Template;
+  async createTemplate(@Body() template: Template, @Req() req: Request): Promise<Template> {
+    if (!req.user) throw new UnauthorizedException('User is not logged in');
+    if (!template) throw new BadRequestException('Template is not defined');
+    template.author = req.user['_id'];
+    return await this.templateService.createTemplate(template);
   }
 
-  // FUTURE TODO: Change service to only return documents where author === req.user._id, pass user or _id to service
-  // FUTURE TODO: Change service to also return public/shared templates
-  // QUESTION: Should terms be excluded from return values to reduce payload?
   @Get('/')
+  @ApiOperation({ summary: 'Returns array of all templates authored by current user' })
   @ApiOkResponse({ description: 'Template list retrieved successfully', type: [Template] })
-  async getTemplates() {
-    return await this.templateService.getAllTemplates();
+  @ApiBadRequestResponse({ description: 'Invalid or missingrequest parameters' })
+  @ApiNotFoundResponse({ description: 'Resource not found' })
+  @ApiUnauthorizedResponse({ description: 'User is not authenticated' })
+  async getTemplates(@Req() req: Request) {
+    if (!req.user) throw new UnauthorizedException('User is not logged in');
+    return await this.templateService.getTemplatesByUserId(req.user['_id']);
   }
 
-  // This could be removed from final implementation
+  // TO BE REMOVED
   @Get('/u/:uid')
+  @ApiOperation({ summary: 'DEPRECATED USE `GET /` INSTEAD. Returns templates matching user ID' })
   @ApiOkResponse({ description: 'Template list for user retrieved successfully', type: Template })
-  @ApiBadRequestResponse({ description: 'Invalid request parameters' })
+  @ApiBadRequestResponse({ description: 'Invalid or missing request parameters' })
   @ApiNotFoundResponse({ description: 'Resource not found' })
   async getTemplatesByUser(@Param('uid') uid: string): Promise<Template[]> {
     return await this.templateService.getTemplatesByUserId(uid);
   }
 
+  @Get('/all')
+  @ApiOperation({ summary: 'Returns array of all templates' })
+  @ApiOkResponse({ description: 'Template list for user retrieved successfully', type: Template })
+  @ApiUnauthorizedResponse({ description: 'User is not authenticated' })
+  async getAllTemplates(@Req() req: Request): Promise<Template[]> {
+    if (!req.user) throw new UnauthorizedException('User is not logged in');
+    return await this.templateService.getAllTemplates();
+  }
+
   @Get('/:id')
+  @ApiOperation({ summary: 'Returns template with given id' })
   @ApiOkResponse({ description: 'Template retrieved successfully', type: Template })
-  @ApiBadRequestResponse({ description: 'Invalid request parameters' })
+  @ApiBadRequestResponse({ description: 'Invalid or missing request parameters' })
   @ApiNotFoundResponse({ description: 'Resource not found' })
-  async getTemplateById(@Param('id') id: string): Promise<Template> {
-    return this.templateService.getTemplateById(id);
+  @ApiUnauthorizedResponse({ description: 'User is not authenticated' })
+  async getTemplateById(@Param('id') id: string, @Req() req: Request): Promise<Template> {
+    if (!req.user) throw new UnauthorizedException('User is not logged in');
+    if (!id) throw new BadRequestException('ID is not defined');
+    // Read operations can be allowed even if user is not author
+    return await this.templateService.getTemplateById(id);
   }
 
   @Patch('/:id')
+  @ApiOperation({ summary: 'Updates template with given id with given template body' })
   @ApiOkResponse({ description: 'Template updated succesfully', type: Boolean })
   @ApiBadRequestResponse({ description: 'Invalid request body or parameters' })
   @ApiNotFoundResponse({ description: 'Resource not found' })
+  @ApiUnauthorizedResponse({ description: 'User is not authenticated' })
+  @ApiForbiddenResponse({ description: 'Access to resource is forbidden (user is not author)' })
   @UsePipes(new ValidationPipe({ transform: true }))
-  async updateTemplate(@Param('id') id: string, @Body() template: Template): Promise<Template> {
+  async updateTemplate(
+    @Param('id') id: string,
+    @Body() template: Template,
+    @Req() req: Request,
+  ): Promise<Template> {
+    if (!req.user) throw new UnauthorizedException('User is not logged in');
+    if (!template) throw new BadRequestException('Template is not defined');
+    if (!id) throw new BadRequestException('ID is not defined');
+    if (!(await this.templateService.verifyAuthor(id, req.user as UserDocument))) {
+      throw new ForbiddenException('Access forbidden');
+    }
     return await this.templateService.updateTemplate(id, template);
   }
 
   @Delete('/:id')
+  @ApiOperation({ summary: 'Deletes template with given id' })
   @ApiOkResponse({ description: 'Template deleted succesfully', type: Boolean })
   @ApiBadRequestResponse({ description: 'Invalid request parameters' })
   @ApiNotFoundResponse({ description: 'Resource not found' })
-  async deleteTemplate(@Param('id') id: string): Promise<boolean> {
+  @ApiUnauthorizedResponse({ description: 'User is not authenticated' })
+  @ApiForbiddenResponse({ description: 'Access to resource is forbidden (user is not author)' })
+  async deleteTemplate(@Param('id') id: string, @Req() req: Request): Promise<boolean> {
+    if (!req.user) throw new UnauthorizedException('User is not logged in');
+    if (!id) throw new BadRequestException('ID is not defined');
+    if (!(await this.templateService.verifyAuthor(id, req.user as UserDocument))) {
+      throw new ForbiddenException('Access forbidden');
+    }
     return await this.templateService.deleteTemplate(id);
   }
 }

--- a/server/src/template/template.service.ts
+++ b/server/src/template/template.service.ts
@@ -48,10 +48,13 @@ export class TemplateService {
 
   // HELPER METHODS ========================================================================
 
-  async verifyAuthor(id: string, user: User): Promise<boolean> {
+  async verifyAuthor(id: Types.ObjectId, userId: Types.ObjectId): Promise<boolean> {
     // Checks if template with given id has given user as author
-    const data = await this.templateModel.findOne({ _id: id, author: user['_id'] });
-    if (!data) return false;
-    return true;
+    if (!Types.ObjectId.isValid(id)) throw new BadRequestException('Invalid id');
+    if (!Types.ObjectId.isValid(userId)) throw new BadRequestException('Invalid user id');
+    const data = await this.templateModel.findById(id);
+    if (!data) throw new NotFoundException('No template matching the id exists');
+    if (data.author.toString() === userId.toString()) return true;
+    return false;
   }
 }

--- a/server/src/template/template.service.ts
+++ b/server/src/template/template.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types } from 'mongoose';
+import { User } from 'src/user/user.schema';
 import { Template, TemplateDocument } from './schemas/template.schema';
 
 @Injectable()
@@ -13,8 +14,6 @@ export class TemplateService {
     return await new this.templateModel(template).save();
   }
 
-  // FUTURE TODO: Change to only find and return documents where author === req.user._id
-  // FUTURE TODO: Change to also return any documents marked as public (e.g. isPublic === true)
   async getAllTemplates(): Promise<Template[]> {
     return await this.templateModel.find().exec();
   }
@@ -45,5 +44,14 @@ export class TemplateService {
     const deleteRes = await this.templateModel.deleteOne({ _id: id }).exec();
     if (!deleteRes.deletedCount) throw new NotFoundException('No template matching the id exists');
     return deleteRes.acknowledged;
+  }
+
+  // HELPER METHODS ========================================================================
+
+  async verifyAuthor(id: string, user: User): Promise<boolean> {
+    // Checks if template with given id has given user as author
+    const data = await this.templateModel.findOne({ _id: id, author: user['_id'] });
+    if (!data) return false;
+    return true;
   }
 }

--- a/server/src/template/test/stubs/template.schema.stub.ts
+++ b/server/src/template/test/stubs/template.schema.stub.ts
@@ -4,7 +4,7 @@ import { TermStub } from './term.schema.stub';
 export const TemplateStub = (): Template => {
   return {
     title: 'Test Template',
-    author: null,
+    author: undefined,
     terms: [TermStub()],
   };
 };
@@ -12,7 +12,7 @@ export const TemplateStub = (): Template => {
 export const UpdatedTemplateStub = (): Template => {
   return {
     title: 'Updated test template',
-    author: null,
+    author: undefined,
     terms: [TermStub()],
   };
 };

--- a/server/src/template/test/template.controller.spec.ts
+++ b/server/src/template/test/template.controller.spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { TemplateController } from '../template.controller';
 import { TemplateService } from '../template.service';
-import { Template, TemplateSchema } from '../schemas/template.schema';
 import { TemplateStub } from '../test/stubs/template.schema.stub';
 
 describe('TemplateController', () => {
@@ -10,6 +9,7 @@ describe('TemplateController', () => {
 
   // Setup testing environment before running any tests
   beforeAll(async () => {
+    // Mocked service interface
     const MockTemplateService = {
       provide: TemplateService,
       useFactory: () => ({
@@ -31,6 +31,9 @@ describe('TemplateController', () => {
         deleteTemplate: jest.fn(() => {
           return true;
         }),
+        verifyAuthor: jest.fn((a, b) => {
+          return a == 'some-id';
+        }),
       }),
     };
 
@@ -42,35 +45,92 @@ describe('TemplateController', () => {
     templateService = app.get<TemplateService>(TemplateService);
   });
 
-  describe('Create Template', () => {
+  describe('Template Controller Methods', () => {
+    // Static mocked values
+    const mockReq = {
+      body: {},
+      user: {
+        username: 'tester',
+        _id: 'test-user-id',
+      },
+    } as any;
+    const mockReqNoUser = {
+      body: {},
+    } as any;
+    const mockId = 'some-id';
+
+    // createTemplate ==========================================================================================
     it('Should be using mocked services for testing', async () => {
+      const nullStub = {
+        title: null,
+        author: null,
+        terms: null,
+      };
+      const expectedCall = nullStub;
+      expectedCall.author = mockReq.user._id;
+
       const spy = jest.spyOn(templateService, 'createTemplate');
-      const createdTemplate = await templateController.createTemplate(null);
+      const createdTemplate = await templateController.createTemplate(nullStub, mockReq);
       expect(spy).toHaveBeenCalled();
-      expect(spy).toHaveBeenCalledWith(null);
-      expect(createdTemplate.title).toBe(TemplateStub().title); // Mocked should return stub given param null
+      expect(spy).toHaveBeenCalledWith(expectedCall);
+      expect(createdTemplate.title).toBe(TemplateStub().title); // Mocked should return same with any parameters
     });
 
-    it('Should call createTemplate & return modified created object', async () => {
+    it('[create] Should call createTemplate & return created object', async () => {
+      const expectedCall = TemplateStub();
+      expectedCall.author = mockReq.user._id;
+
       const spy = jest.spyOn(templateService, 'createTemplate');
-      const createdTemplate = await templateController.createTemplate(TemplateStub());
+      const createdTemplate = await templateController.createTemplate(TemplateStub(), mockReq);
       expect(spy).toHaveBeenCalled();
-      expect(spy).toHaveBeenCalledWith(TemplateStub());
+      expect(spy).toHaveBeenCalledWith(expectedCall);
       expect(createdTemplate.title).toBe(TemplateStub().title);
-      expect(createdTemplate.author).toBe(TemplateStub().author);
       expect(createdTemplate.terms).toStrictEqual(TemplateStub().terms);
-      expect(createdTemplate).toHaveProperty('_id'); // Controller adds property _id  before returning
     });
 
-    it('Should call getAllTemplates & return array of documents', async () => {
+    it('[create] Should throw BadRequest for missing template', async () => {
+      const errMsg = 'Template is not defined';
+      await expect(templateController.createTemplate(null, mockReq)).rejects.toThrow(errMsg);
+    });
+
+    it('[create] Should throw Unauthorized for missing req.user', async () => {
+      const errMsg = 'User is not logged in';
+      await expect(
+        templateController.createTemplate(TemplateStub(), mockReqNoUser),
+      ).rejects.toThrow(errMsg);
+    });
+
+    // getTemplates ==========================================================================================
+    it('[get] Should call getTemplatesByUserId & return array of documents', async () => {
+      const spy = jest.spyOn(templateService, 'getTemplatesByUserId');
+      const getAll = await templateController.getTemplates(mockReq);
+      expect(spy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith(mockReq.user._id);
+      expect(getAll).toHaveLength(1);
+      expect(getAll[0]).toStrictEqual(TemplateStub());
+    });
+
+    it('[get] Should throw Unauthorized for missing req.user', async () => {
+      const errMsg = 'User is not logged in';
+      await expect(templateController.getTemplates(mockReqNoUser)).rejects.toThrow(errMsg);
+    });
+
+    // getAllTemplates ==========================================================================================
+    it('[getAll] Should call getAllTemplates & return array of documents', async () => {
       const spy = jest.spyOn(templateService, 'getAllTemplates');
-      const getAll = await templateController.getTemplates();
+      const getAll = await templateController.getAllTemplates(mockReq);
       expect(spy).toHaveBeenCalled();
       expect(getAll).toHaveLength(1);
       expect(getAll[0]).toStrictEqual(TemplateStub());
     });
 
-    it('Should call getTemplatesByUserId & return array of documents', async () => {
+    it('[getAll] Should throw Unauthorized for missing req.user', async () => {
+      const errMsg = 'User is not logged in';
+      await expect(templateController.getAllTemplates(mockReqNoUser)).rejects.toThrow(errMsg);
+    });
+
+    // DEPRECATED
+    /* it('Should call getTemplatesByUserId & return array of documents', async () => {
       const someUid = 'some-uid';
       const spy = jest.spyOn(templateService, 'getTemplatesByUserId');
       const getByUid = await templateController.getTemplatesByUser(someUid);
@@ -78,35 +138,106 @@ describe('TemplateController', () => {
       expect(spy).toHaveBeenCalledWith(someUid);
       expect(getByUid).toHaveLength(1);
       expect(getByUid[0]).toStrictEqual(TemplateStub());
-    });
+    }); */
 
-    it('Should call getTemplateById & return found document', async () => {
-      // Note: Query related raised errors, like 404, are thrown and tested in services.
-      const someId = 'some-id';
+    // getTemplateById ==========================================================================================
+    it('[getById] Should call getTemplateById & return found document', async () => {
       const spy = jest.spyOn(templateService, 'getTemplateById');
-      const getById = await templateController.getTemplateById(someId);
+      const getById = await templateController.getTemplateById(mockId, mockReq);
       expect(spy).toHaveBeenCalled();
-      expect(spy).toHaveBeenCalledWith(someId);
+      expect(spy).toHaveBeenCalledWith(mockId);
       expect(getById).toStrictEqual(TemplateStub());
     });
 
-    it('Should call updateTemplate & return updated document', async () => {
-      const someId = 'some-id';
+    it('[getById] Should throw Unauthorized for missing req.user', async () => {
+      const errMsg = 'User is not logged in';
+      await expect(templateController.getTemplateById(mockId, mockReqNoUser)).rejects.toThrow(
+        errMsg,
+      );
+    });
+
+    it('[getById] Should throw BadRequest for missing ID', async () => {
+      const errMsg = 'ID is not defined';
+      await expect(templateController.getTemplateById(null, mockReq)).rejects.toThrow(errMsg);
+    });
+
+    // updateTemplate ==========================================================================================
+    it('[update] Should call updateTemplate & return updated document', async () => {
       const spy = jest.spyOn(templateService, 'updateTemplate');
-      const updatedTemplate = await templateController.updateTemplate(someId, TemplateStub());
+      const spy2 = jest.spyOn(templateService, 'verifyAuthor');
+      const updatedTemplate = await templateController.updateTemplate(
+        mockId,
+        TemplateStub(),
+        mockReq,
+      );
       expect(spy).toHaveBeenCalled();
-      expect(spy.mock.calls[0][0]).toBe(someId);
+      expect(spy.mock.calls[0][0]).toBe(mockId);
       expect(spy.mock.calls[0][1]).toStrictEqual(TemplateStub());
+      expect(spy2).toHaveBeenCalled();
+      expect(spy2.mock.calls[0][0]).toBe(mockId);
+      expect(spy2.mock.calls[0][1]).toStrictEqual(mockReq.user);
+      expect(spy2.mock.results[0].value).toBeTruthy();
       expect(updatedTemplate).toStrictEqual(TemplateStub());
     });
 
-    it('Should call deleteTemplate & return boolean', async () => {
-      const someId = 'some-id';
+    it('[update] Should throw Unauthorized for missing req.user', async () => {
+      const errMsg = 'User is not logged in';
+      await expect(
+        templateController.updateTemplate(mockId, TemplateStub(), mockReqNoUser),
+      ).rejects.toThrow(errMsg);
+    });
+
+    it('[update] Should throw BadRequest for missing Template', async () => {
+      const errMsg = 'Template is not defined';
+      await expect(templateController.updateTemplate(mockId, null, mockReq)).rejects.toThrow(
+        errMsg,
+      );
+    });
+
+    it('[update] Should throw BadRequest for missing ID', async () => {
+      const errMsg = 'ID is not defined';
+      await expect(
+        templateController.updateTemplate(null, TemplateStub(), mockReq),
+      ).rejects.toThrow(errMsg);
+    });
+
+    it('[update] Should throw BadRequest for missing ID', async () => {
+      const otherId = 'other-id';
+      const errMsg = 'Access forbidden';
+      await expect(
+        templateController.updateTemplate(otherId, TemplateStub(), mockReq),
+      ).rejects.toThrow(errMsg);
+    });
+
+    // deleteTemplate ==========================================================================================
+    it('[delete] Should call deleteTemplate & return boolean', async () => {
       const spy = jest.spyOn(templateService, 'deleteTemplate');
-      const deletedTemplate = await templateController.deleteTemplate(someId);
+      const spy2 = jest.spyOn(templateService, 'verifyAuthor');
+      const deletedTemplate = await templateController.deleteTemplate(mockId, mockReq);
       expect(spy).toHaveBeenCalled();
-      expect(spy).toHaveBeenCalledWith(someId);
+      expect(spy).toHaveBeenCalledWith(mockId);
+      expect(spy2).toHaveBeenCalled();
+      expect(spy2.mock.calls[0][0]).toBe(mockId);
+      expect(spy2.mock.calls[0][1]).toStrictEqual(mockReq.user);
       expect(deletedTemplate).toBeTruthy();
+    });
+
+    it('[delete] Should throw Unauthorized for missing req.user', async () => {
+      const errMsg = 'User is not logged in';
+      await expect(templateController.deleteTemplate(mockId, mockReqNoUser)).rejects.toThrow(
+        errMsg,
+      );
+    });
+
+    it('[delete]Should throw BadRequest for missing ID', async () => {
+      const errMsg = 'ID is not defined';
+      await expect(templateController.deleteTemplate(null, mockReq)).rejects.toThrow(errMsg);
+    });
+
+    it('[delete] Should throw BadRequest for missing ID', async () => {
+      const otherId = 'other-id';
+      const errMsg = 'Access forbidden';
+      await expect(templateController.deleteTemplate(otherId, mockReq)).rejects.toThrow(errMsg);
     });
   });
 });

--- a/server/src/template/test/template.controller.spec.ts
+++ b/server/src/template/test/template.controller.spec.ts
@@ -175,7 +175,7 @@ describe('TemplateController', () => {
       expect(spy.mock.calls[0][1]).toStrictEqual(TemplateStub());
       expect(spy2).toHaveBeenCalled();
       expect(spy2.mock.calls[0][0]).toBe(mockId);
-      expect(spy2.mock.calls[0][1]).toStrictEqual(mockReq.user);
+      expect(spy2.mock.calls[0][1]).toStrictEqual(mockReq.user._id);
       expect(spy2.mock.results[0].value).toBeTruthy();
       expect(updatedTemplate).toStrictEqual(TemplateStub());
     });
@@ -218,7 +218,7 @@ describe('TemplateController', () => {
       expect(spy).toHaveBeenCalledWith(mockId);
       expect(spy2).toHaveBeenCalled();
       expect(spy2.mock.calls[0][0]).toBe(mockId);
-      expect(spy2.mock.calls[0][1]).toStrictEqual(mockReq.user);
+      expect(spy2.mock.calls[0][1]).toStrictEqual(mockReq.user._id);
       expect(deletedTemplate).toBeTruthy();
     });
 

--- a/server/src/template/test/template.service.spec.ts
+++ b/server/src/template/test/template.service.spec.ts
@@ -208,5 +208,32 @@ describe('TemplateController', () => {
       const verify = await templateService.verifyAuthor(created._id, user2._id);
       expect(verify).toBeFalsy();
     });
+
+    it('verifyAuthor should throw NotFound for no matching template', async () => {
+      const user = {
+        _id: new Types.ObjectId('6380c7d7ca85580f1d5b69eb'),
+      } as any;
+      const errMsg = 'No template matching the id exists';
+      const created = (await templateService.createTemplate(TemplateStub())) as TemplateDocument;
+      await templateService.deleteTemplate(created._id);
+      await expect(templateService.verifyAuthor(created._id, user._id)).rejects.toThrow(
+        NotFoundException,
+      );
+      await expect(templateService.verifyAuthor(created._id, user._id)).rejects.toThrow(errMsg);
+    });
+
+    it('verifyAuthor should throw BadRequest for bad id', async () => {
+      const uid = new Types.ObjectId('6380c7d7ca85580f1d5b69eb');
+      const errMsg = 'Invalid id';
+      await expect(templateService.verifyAuthor(null, uid)).rejects.toThrow(BadRequestException);
+      await expect(templateService.verifyAuthor(null, uid)).rejects.toThrow(errMsg);
+    });
+
+    it('verifyAuthor should throw BadRequest for bad user id', async () => {
+      const id = new Types.ObjectId('6280c7d7ca85580f1d5b69eb');
+      const errMsg = 'Invalid user id';
+      await expect(templateService.verifyAuthor(id, null)).rejects.toThrow(BadRequestException);
+      await expect(templateService.verifyAuthor(id, null)).rejects.toThrow(errMsg);
+    });
   });
 });

--- a/server/src/template/test/template.service.spec.ts
+++ b/server/src/template/test/template.service.spec.ts
@@ -146,7 +146,7 @@ describe('TemplateController', () => {
       await expect(templateService.deleteTemplate(created._id)).rejects.toThrow(errMsg);
     });
 
-    it('', async () => {
+    it('Should find and return documents by userID', async () => {
       const user = {
         _id: new Types.ObjectId('6380c7d7ca85580f1d5b69eb'),
       } as any;
@@ -163,7 +163,7 @@ describe('TemplateController', () => {
       expect(getByUid[0]).toHaveProperty('updatedAt');
     });
 
-    it('getTemplateById Should throw BadRequest for Invalid ID', async () => {
+    it('getTemplateByUserId Should throw BadRequest for Invalid userID', async () => {
       const errMsg = 'Invalid user id';
       await expect(templateService.getTemplatesByUserId('abc')).rejects.toThrow(
         BadRequestException,
@@ -171,7 +171,7 @@ describe('TemplateController', () => {
       await expect(templateService.getTemplatesByUserId('abc')).rejects.toThrow(errMsg);
     });
 
-    it('getTemplateById Should throw NotFound for no matches', async () => {
+    it('getTemplateByUserId Should throw NotFound for no matches', async () => {
       const user = {
         _id: new Types.ObjectId('6380c7d7ca85580f1d5b69eb'),
       } as any;
@@ -183,6 +183,30 @@ describe('TemplateController', () => {
       );
       await expect(templateService.getTemplatesByUserId(user._id)).rejects.toThrow(errMsg);
     });
-    // TODO: Get by UID, unless method is retired
+
+    it('verifyAuthor should return true', async () => {
+      const user = {
+        _id: new Types.ObjectId('6380c7d7ca85580f1d5b69eb'),
+      } as any;
+      const stubWithUser = TemplateStub();
+      stubWithUser.author = user._id;
+      const created = (await templateService.createTemplate(stubWithUser)) as TemplateDocument;
+      const verify = await templateService.verifyAuthor(created._id, user._id);
+      expect(verify).toBeTruthy();
+    });
+
+    it('verifyAuthor should return false', async () => {
+      const user = {
+        _id: new Types.ObjectId('6380c7d7ca85580f1d5b69eb'),
+      } as any;
+      const user2 = {
+        _id: new Types.ObjectId('6280c7d7ca85580f1d5b69eb'),
+      } as any;
+      const stubWithUser = TemplateStub();
+      stubWithUser.author = user._id;
+      const created = (await templateService.createTemplate(stubWithUser)) as TemplateDocument;
+      const verify = await templateService.verifyAuthor(created._id, user2._id);
+      expect(verify).toBeFalsy();
+    });
   });
 });


### PR DESCRIPTION
Template controller updated to use req.user to determine current user.
- createTemplate adds current as author
- getTemplates gets templates by current user
- added getAllTemplates for retrieving all templates
- getTemplatesByUser set to be deprecated (unless needed elsewhere). Use getTemplates instead
- updateTemplate and deleteTemplate check for resource ownership before executing changes
 - added verifyAuthor helper method to template service
- All up-to-date methods check for user authentication
- Added controller-side parameter-exists -checks

Unit Tests have been updated and finalized
- Controller tests use mocked requests
- Service mock verifyAuthor can return true or false (return a == 'some-id')
- Controller tests should now cover all execution paths
- Service unit tests were expanded to include user id:s in getTemplatesByUserId and VerifyAuthor
- Service tests should now cover all execution paths
 - Pre-made validation pipeline-related errors are not covered