### PR TITLE
Restricted coverage to tested file types

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -83,7 +83,7 @@
       "^.+\\.(t|j)s$": "ts-jest"
     },
     "collectCoverageFrom": [
-      "**/*.(t|j)s"
+      "**/*.(controller|service|schema).(t|j)s"
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"


### PR DESCRIPTION
Modified jest collectCoverageFrom configuration to only collect coverage data from files relevant to or subject to testing.