### PR TITLE
Robot test fixes

### DIFF
--- a/robot/02__web/01_register.robot
+++ b/robot/02__web/01_register.robot
@@ -5,7 +5,8 @@ Resource    ../resources.robot
 
 *** Variables ***
 ${USERNAME}
-${PASSWORD}=    asdasd123123
+${PASSWORD_WEB}=    asdasd123123
+${PASSWORD}
 ${FIRST_NAME}=    Testi
 ${LAST_NAME}=    Testinen
 ${EMAIL}=    testi@testi.fi
@@ -15,7 +16,7 @@ Set Variables
     [Documentation]    Set global variables to be used by browser FW tests
     ${epoch}    Get Time    epoch
     Set Global Variable    ${USERNAME}    user_${epoch}
-    Set Global Variable    ${PASSWORD}
+    Set Global Variable    ${PASSWORD}    ${PASSWORD_WEB}
     Set Global Variable    ${FIRST_NAME}
     Set Global Variable    ${LAST_NAME}
     Set Global Variable    ${EMAIL}

--- a/robot/02__web/05_search.robot
+++ b/robot/02__web/05_search.robot
@@ -40,7 +40,7 @@ See results
 
 Check result validity
     [Documentation]    Todo: Rework this
-    Get Element    "key: Total"
-    Get Element    "value: $93.50"
-    Get Element    "key: Web Design"
-    Get Element    "value: This is a sample description..."
+    Get Element    "Total"
+    Get Element    "$93.50"
+    Get Element    "Web Design"
+    Get Element    "This is a sample description..."


### PR DESCRIPTION
- Fix setting global variable password
  - It used to assign itself again, which made the web tests use same pw as endpoint tests
- Change get element selectors in search tests
  - Not quite optimal, but gets the job done